### PR TITLE
fix(ec-admin-settings-form): split field using boolean filter to avoid empty string

### DIFF
--- a/src/components/js/EcAdminSettingsForm.js
+++ b/src/components/js/EcAdminSettingsForm.js
@@ -222,7 +222,7 @@ export default {
                       const isArrayIndex = /^\d+$/.test(fields[i + 1])
                       nestedField[fields[i]] = isArrayIndex ? [] : {}
                     }
-                    nestedField = nestedField[fields[i]] 
+                    nestedField = nestedField[fields[i]]
                   }
                   nestedField[fields[fields.length - 1]] = value
                 } else {

--- a/src/components/js/EcAdminSettingsForm.js
+++ b/src/components/js/EcAdminSettingsForm.js
@@ -214,15 +214,16 @@ export default {
                   : head.startsWith('Boolean')
                     ? Boolean(row[head] && !row[head].toUpperCase().startsWith('FALS'))
                     : row[head]
-                const fields = field.split(/[.[\]]/)
+                const fields = field.split(/[\[\].]+/).filter(Boolean)
+                let isArrayIndex = false
                 if (fields.length > 1) {
                   let nestedField = parsedData
                   for (let i = 0; i < fields.length - 1; i++) {
                     if (!nestedField[fields[i]]) {
-                      const isArrayIndex = /^\d+$/.test(fields[i + 1])
+                      isArrayIndex = /^\d+$/.test(fields[i + 1])
                       nestedField[fields[i]] = isArrayIndex ? [] : {}
                     }
-                    nestedField = nestedField[fields[i]]
+                    nestedField = nestedField[fields[i]] 
                   }
                   nestedField[fields[fields.length - 1]] = value
                 } else {

--- a/src/components/js/EcAdminSettingsForm.js
+++ b/src/components/js/EcAdminSettingsForm.js
@@ -215,12 +215,11 @@ export default {
                     ? Boolean(row[head] && !row[head].toUpperCase().startsWith('FALS'))
                     : row[head]
                 const fields = field.split(/[\[\].]+/).filter(Boolean)
-                let isArrayIndex = false
                 if (fields.length > 1) {
                   let nestedField = parsedData
                   for (let i = 0; i < fields.length - 1; i++) {
                     if (!nestedField[fields[i]]) {
-                      isArrayIndex = /^\d+$/.test(fields[i + 1])
+                      const isArrayIndex = /^\d+$/.test(fields[i + 1])
                       nestedField[fields[i]] = isArrayIndex ? [] : {}
                     }
                     nestedField = nestedField[fields[i]] 

--- a/src/components/js/EcAdminSettingsForm.js
+++ b/src/components/js/EcAdminSettingsForm.js
@@ -214,7 +214,7 @@ export default {
                   : head.startsWith('Boolean')
                     ? Boolean(row[head] && !row[head].toUpperCase().startsWith('FALS'))
                     : row[head]
-                const fields = field.split(/[\[\].]+/).filter(Boolean)
+                const fields = field.split(/[.[\]]/).filter(Boolean)
                 if (fields.length > 1) {
                   let nestedField = parsedData
                   for (let i = 0; i < fields.length - 1; i++) {


### PR DESCRIPTION
Da outra forma, quando importava uma tabela com String(product_ids[0]), fields = ["product_ids", "0", ""], com novo ajuste no split filtrando, retorna fields = ["product_ids", "0"], qualquer "" é desconsiderado. Testei com vários formatos e funcionou.